### PR TITLE
Set up for gem publishing, and consume the gem as the theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-gemspec
 
 gem "webrick", "~> 1.7"
+gem "just-the-hm-docs", ">= 1.0.0.rc1"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The theme is distributed as a Ruby gem so that it can be easily consumed by any 
 
 The action only runs when triggered manually. To do so, run the ["Publish Ruby Gem"](https://github.com/humanmade/just-the-hm-docs/actions/workflows/publish-gem.yml) action.
 
-In order to push to rubygems.org, the action needs access to an auth token. The auth token can be set via [`Security / Secrets and variables / Actions`](https://github.com/humanmade/just-the-hm-docs/settings/secrets/actions). To create a new token, an authorized gem owner will need to create a new one from the [`API Keys`](https://rubygems.org/profile/api_keys) setting area on rubygems.org.
+In order to push to rubygems.org, the action needs access to an auth token. The auth token can be set via [`Security / Secrets and variables / Actions`](https://github.com/humanmade/just-the-hm-docs/settings/secrets/actions). To create a new token, an authorized gem owner will need to create a new one from the [`API Keys`](https://rubygems.org/profile/api_keys) setting area on rubygems.org. Once created, add the token with the name `RUBYGEMS_AUTH_TOKEN`.
 
 **NOTE:** The API key used needs to be accessible by machines *without* 2FA—otherwise the automated deployment will fail becuase it will be prompted for an OTP in a non-interactive environment. *If the security tradeoff seems reasonable* the MFA level for a rubygems.org account can be set to "UA and gem signin," which will prompt for 2FA on the website and with the `gem signin` command, but *not* for `gem push`, allowing the automated gem deploy action to work.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Getting started with Just the HM Docs is simple.
 
 Just the HM Docs requires no special Jekyll plugins and can run on GitHub Pages' standard Jekyll compiler. To setup a local development environment, clone your template repository and follow the GitHub Docs on [Testing your GitHub Pages site locally with Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll).
 
+## Publishing a Gem
+
+The theme is distributed as a Ruby gem so that it can be easily consumed by any Jekyll site. New versions can be published by anything with access to [the gem](https://rubygems.org/gems/just-the-hm-docs/) manually, but there is also a GitHub Action set up to automate publishing to rubygems.org and the GitHub package repository.
+
+The action only runs when triggered manually. To do so, run the ["Publish Ruby Gem"](https://github.com/humanmade/just-the-hm-docs/actions/workflows/publish-gem.yml) action.
+
+In order to push to rubygems.org, the action needs access to an auth token. The auth token can be set via [`Security / Secrets and variables / Actions`](https://github.com/humanmade/just-the-hm-docs/settings/secrets/actions). To create a new token, an authorized gem owner will need to create a new one from the [`API Keys`](https://rubygems.org/profile/api_keys) setting area on rubygems.org.
+
+**NOTE:** The API key used needs to be accessible by machines *without* 2FA—otherwise the automated deployment will fail becuase it will be prompted for an OTP in a non-interactive environment. *If the security tradeoff seems reasonable* the MFA level for a rubygems.org account can be set to "UA and gem signin," which will prompt for 2FA on the website and with the `gem signin` command, but *not* for `gem push`, allowing the automated gem deploy action to work.
+
 ## License
 
 The theme is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ logo: "/assets/images/hm-logo.svg"
 favicon_ico: "/assets/favicon/favicon.ico"
 
 # Theme settings
+theme: just-the-hm-docs
 color_scheme: hm
 permalink: pretty
 

--- a/just-the-hm-docs.gemspec
+++ b/just-the-hm-docs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "just-the-hm-docs"
-  spec.version       = "0.4.0.rc4"
+  spec.version       = "1.0.0.rc1"
   spec.authors       = ["Human Made"]
   spec.email         = ["info@humanmade.com"]
 


### PR DESCRIPTION
Most of what this PR "does" is already part of `just-the-docs`: I've just made certain things work and slightly massaged some versions. I've updated the readme to explain how gem publishing works, and taken the following steps (which are not code-based and hence not reflected in this PR):

- Pushed an initial version of the theme gem (`v1.0.0.rc1`) to rubygems.org and the GitHub package repository. The rubygems.org version is [here](https://rubygems.org/gems/just-the-hm-docs). The GitHub version is [here](https://github.com/orgs/humanmade/packages/rubygems/package/just-the-hm-docs). **NOTE:** I set this up on my own rubygems.org account, but ***I should not have sole control over this package***. I am happy to invite other owners ASAP; You just need to create an account on rubygems.org and tell me the email address you used so I can add you as an owner. I'd recommend adding at least @joeleenk and @kadamwhite, but I'm happy to relinquish the gem to anyone.
- Added my rubygems.org API key to this repo, to allow for automated gem pushes via the Action. **I recommend changing this to someone else's API key ASAP.**
- Deployed the repo to GitHub Pages after configuring the repo to use Actions for Pages deploys. See: https://github.com/humanmade/just-the-hm-docs/settings/pages Note that this means (as of now) GH Pages deploys are _manual_—you have to run the ["Deploy Jekyll site to GitHub Pages"](https://github.com/humanmade/just-the-hm-docs/actions/workflows/deploy.yml) action through the GH UI.

Both of the manual Actions mentioned here (release gem; publish to GH Pages) could be automated in the same way you'd automate other GH Actions, but determining _when_ that automation should happen and implementing it is outside the scope of this PR.

While this sets up the gem to be released and consumed by themes, it doesn't include instructions on setting up a new repo to use the theme for its docs: That's left to a separate PR.