### PR TITLE
Rework styles to work with both older and newer versions of sass compilers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v2
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/_sass/color_schemes/hm.scss
+++ b/_sass/color_schemes/hm.scss
@@ -17,10 +17,10 @@ $search-result-preview-color: $hm-navy-1000;
 $sidebar-color: $hm-navy-100;
 
 // Override theme variables.
-$border-radius: rem(6px);
-$content-width: 915px;
+$border-radius: rem(6);
+$content-width: 915;
 $gutter-spacing: $sp-7;
-$header-height: 70px;
+$header-height: 70;
 $nav-list-item-height: $spacing-unit * 3.2;
 $nav-list-item-height-sm: $spacing-unit * 3.2;
-$nav-width: 276px;
+$nav-width: 276;

--- a/_sass/custom/hm-branding.scss
+++ b/_sass/custom/hm-branding.scss
@@ -164,7 +164,7 @@ h6 {
 
 .site-title {
   @include mq(md) {
-    font-size: rem(21px) !important;
+    font-size: rem(21) !important;
     padding-bottom: $gutter-spacing-sm;
     padding-top: $gutter-spacing-sm;
   }
@@ -177,10 +177,10 @@ h6 {
 
   &::after {
     content: "Documentation";
-    padding-left: rem(62px);
+    padding-left: rem(62);
 
     @include mq(md) {
-      padding-left: rem(53px);
+      padding-left: rem(53);
     }
   }
 }
@@ -205,7 +205,7 @@ h6 {
   .nav-list-link {
     outline-offset: -1px;
     text-decoration: underline;
-    text-underline-offset: rem(3px);
+    text-underline-offset: rem(3);
 
     .nav-list .nav-list-item > &:hover,
     &:hover,
@@ -246,8 +246,8 @@ h6 {
 }
 
 .search-label .search-icon {
-  height: rem(22px);
-  width: rem(22px);
+  height: rem(22);
+  width: rem(22);
 }
 
 .search-result {

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -34,7 +34,7 @@
     margin-left: max(
       $nav-width * 1px,
       calc(
-        (100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)}
+        (100% - #{($nav-width + $content-width) * 1px}) / 2 + #{$nav-width * 1px}
       )
     );
   }

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -4,14 +4,22 @@
   --sidebar-width: #{rem($nav-width-md)};
 
   @include mq(lg) {
-    --sidebar-width: calc((100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)});
+    --sidebar-width: calc(
+      (100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)}
+    );
   }
 }
 
 body {
+  position: relative;
+  padding-bottom: $sp-10;
+  overflow-y: scroll;
+
   @include mq(md) {
     display: grid;
     grid-template-columns: rem($nav-width-md) 1fr;
+    position: static;
+    padding-bottom: 0;
   }
 
   @include mq(lg) {
@@ -177,21 +185,6 @@ body {
     rgba($feedback-color, 0.8) 100%
   );
 }
-
-// stylelint-disable selector-max-type
-
-body {
-  position: relative;
-  padding-bottom: $sp-10;
-  overflow-y: scroll;
-
-  @include mq(md) {
-    position: static;
-    padding-bottom: 0;
-  }
-}
-
-// stylelint-enable selector-max-type
 
 .site-footer {
   @include container;

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -1,7 +1,22 @@
 // The basic two column layout
 
 :root {
-  --sidebar-width: calc((100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)});
+  --sidebar-width: #{rem($nav-width-md)};
+
+  @include mq(lg) {
+    --sidebar-width: calc((100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)});
+  }
+}
+
+body {
+  @include mq(md) {
+    display: grid;
+    grid-template-columns: rem($nav-width-md) 1fr;
+  }
+
+  @include mq(lg) {
+    grid-template-columns: minmax(rem($nav-width), var(--sidebar-width)) 1fr;
+  }
 }
 
 .side-bar {
@@ -13,30 +28,22 @@
   @include mq(md) {
     flex-flow: column nowrap;
     position: fixed;
-    width: rem($nav-width-md);
+    width: var(--sidebar-width);
     height: 100%;
     border-right: $border $border-color;
     align-items: flex-end;
   }
 
   @include mq(lg) {
-    width: var(--sidebar-width);
     min-width: rem($nav-width);
   }
 }
 
 .main {
   @include mq(md) {
+    grid-column-start: 2;
     position: relative;
     max-width: rem($content-width);
-    margin-left: rem($nav-width-md);
-  }
-
-  @include mq(lg) {
-    margin-left: max(
-      $nav-width * 1px,
-      var(--sidebar-width)
-    );
   }
 }
 

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -32,7 +32,7 @@
 
   @include mq(lg) {
     margin-left: max(
-      calc(rem($nav-width)),
+      $nav-width * 1px,
       calc(
         (100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)}
       )

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -32,7 +32,7 @@
 
   @include mq(lg) {
     margin-left: max(
-      rem($nav-width),
+      calc(rem($nav-width)),
       calc(
         (100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)}
       )

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -9,29 +9,33 @@
   @include mq(md) {
     flex-flow: column nowrap;
     position: fixed;
-    width: $nav-width-md;
+    width: rem($nav-width-md);
     height: 100%;
     border-right: $border $border-color;
     align-items: flex-end;
   }
 
   @include mq(lg) {
-    width: calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width});
-    min-width: $nav-width;
+    width: calc(
+      (100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)}
+    );
+    min-width: rem($nav-width);
   }
 }
 
 .main {
   @include mq(md) {
     position: relative;
-    max-width: $content-width;
-    margin-left: $nav-width-md;
+    max-width: rem($content-width);
+    margin-left: rem($nav-width-md);
   }
 
   @include mq(lg) {
     margin-left: max(
-      $nav-width,
-      calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width})
+      rem($nav-width),
+      calc(
+        (100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)}
+      )
     );
   }
 }
@@ -56,7 +60,7 @@
   @include mq(md) {
     display: flex;
     justify-content: space-between;
-    height: $header-height;
+    height: rem($header-height);
     background-color: $body-background-color;
     border-bottom: $border $border-color;
   }
@@ -76,7 +80,7 @@
   width: 100%;
 
   @include mq(lg) {
-    width: $nav-width;
+    width: rem($nav-width);
   }
 }
 
@@ -98,12 +102,12 @@
 
 .site-header {
   display: flex;
-  min-height: $header-height;
+  min-height: rem($header-height);
   align-items: center;
 
   @include mq(md) {
-    height: $header-height;
-    max-height: $header-height;
+    height: rem($header-height);
+    max-height: rem($header-height);
     border-bottom: $border $border-color;
   }
 }

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -1,5 +1,9 @@
 // The basic two column layout
 
+:root {
+  --sidebar-width: calc((100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)});
+}
+
 .side-bar {
   z-index: 0;
   display: flex;
@@ -16,9 +20,7 @@
   }
 
   @include mq(lg) {
-    width: calc(
-      (100% - #{rem($nav-width + $content-width)}) / 2 + #{rem($nav-width)}
-    );
+    width: var(--sidebar-width);
     min-width: rem($nav-width);
   }
 }
@@ -33,9 +35,7 @@
   @include mq(lg) {
     margin-left: max(
       $nav-width * 1px,
-      calc(
-        (100% - #{($nav-width + $content-width) * 1px}) / 2 + #{$nav-width * 1px}
-      )
+      var(--sidebar-width)
     );
   }
 }

--- a/_sass/support/_functions.scss
+++ b/_sass/support/_functions.scss
@@ -1,7 +1,7 @@
 @use "sass:math";
 
 @function rem($size, $unit: "") {
-  $rem-size: math.div($size, $root-font-size);
+  $rem-size: $size * $root-font-size-rem-base;
 
   @if $unit == false {
     @return #{$rem-size};

--- a/_sass/support/_variables.scss
+++ b/_sass/support/_variables.scss
@@ -4,6 +4,7 @@ $body-font-family: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI",
   roboto, "Helvetica Neue", arial, sans-serif !default;
 $mono-font-family: "SFMono-Regular", menlo, consolas, monospace !default;
 $root-font-size: 16px !default; // Base font-size for rems
+$root-font-size-rem-base: 0.0625 !default; // 1 divided by base font-size for rem function.
 $body-line-height: 1.4 !default;
 $content-line-height: 1.6 !default;
 $body-heading-line-height: 1.25 !default;
@@ -108,22 +109,22 @@ $border-color: $grey-lt-100 !default;
 
 $gutter-spacing: $sp-6 !default;
 $gutter-spacing-sm: $sp-4 !default;
-$nav-width: 264px !default;
-$nav-width-md: 248px !default;
+$nav-width: 264 !default;
+$nav-width-md: 248 !default;
 $nav-list-item-height: $sp-6 !default;
 $nav-list-item-height-sm: $sp-8 !default;
 $nav-list-expander-right: true;
-$content-width: 800px !default;
-$header-height: 60px !default;
-$search-results-width: $content-width - $nav-width !default;
+$content-width: 800 !default;
+$header-height: 60 !default;
+$search-results-width: rem($content-width - $nav-width) !default;
 $transition-duration: 400ms;
 
 // Media queries in pixels
 
 $media-queries: (
-  xs: 320px,
-  sm: 500px,
+  xs: 320,
+  sm: 500,
   md: $content-width,
   lg: $content-width + $nav-width,
-  xl: 1400px,
+  xl: 1400,
 ) !default;


### PR DESCRIPTION
When we forked "Just the Docs", we updated the rem function to use `math.div` instead of `/` to correct local errors and modernize the code. However, GitHub pages is still using an old Sass compiler, so this is failing the build process.

This PR reworks the styles so that they will work with either compiler.

- Use a percentage multiplier instead of dividing in the rem function
- Switch layout size variables to unitless numbers
- Update layout to use grid so that the max function is not necessary for the content margin