### PR TITLE
Update to Jekyll 4, add docs for Front Matter layout defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
-gem "webrick", "~> 1.7"
-gem "just-the-hm-docs", ">= 1.0.1.rc1"
+gem "jekyll", "~> 4.3.2"
+gem "webrick", "~> 1.8"
+gem "just-the-hm-docs", ">= 1.0.2.rc1"

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.2"
 gem "webrick", "~> 1.8"
-gem "just-the-hm-docs", ">= 1.0.2.rc1"
+gem "just-the-hm-docs", github: "humanmade/just-the-hm-docs"

--- a/_config.yml
+++ b/_config.yml
@@ -176,10 +176,3 @@ compress_html:
   profile: false
   # ignore:
   #   envs: all
-
-defaults:
-  -
-    scope:
-      path: "" # an empty string here means all files in the project
-    values:
-      layout: "default"

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@
 # feature for the data you need to update frequently.
 #
 # For technical reasons, this file is *NOT* reloaded automatically when you use
-# 'jekyll serve'. If you change this file, please restart the server process.
+# "jekyll serve". If you change this file, please restart the server process.
 
 # Site settings
 # These are used to personalize your new site. If you look in the HTML files,
@@ -17,8 +17,8 @@ title: Just the HM Docs
 tagline: A Jekyll template for documenting Human Made open source projects
 description: A modern, highly customizable, responsive Jekyll template for documentation
 author: Human Made
-baseurl: '/just-the-hm-docs' # the subpath of your site, e.g. /blog
-url: 'https://humanmade.github.io' # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/just-the-hm-docs" # the subpath of your site, e.g. /blog
+url: "https://humanmade.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Set a path/url to a logo that will be displayed instead of the title
 logo: "/assets/icons/hm-logo.svg"
@@ -100,9 +100,9 @@ heading_anchors: true
 # Aux links for the upper right navigation
 aux_links:
   Human Made:
-    - 'https://humanmade.com'
+    - "https://humanmade.com"
   Just the HM Docs on GitHub:
-    - 'https://github.com/humanmade/just-the-hm-docs'
+    - "https://github.com/humanmade/just-the-hm-docs"
 
 # Makes Aux links open in a new tab. Default is false
 aux_links_new_tab: false

--- a/_config.yml
+++ b/_config.yml
@@ -178,3 +178,10 @@ compress_html:
   profile: false
   # ignore:
   #   envs: all
+
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+    values:
+      layout: "default"

--- a/_config.yml
+++ b/_config.yml
@@ -99,8 +99,6 @@ heading_anchors: true
 
 # Aux links for the upper right navigation
 aux_links:
-  Human Made:
-    - "https://humanmade.com"
   Just the HM Docs on GitHub:
     - "https://github.com/humanmade/just-the-hm-docs"
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,8 @@ nav_order: 99
 
 - Update Jekyll version to 4.3.2
 - Update Webrick to 1.8
-- Add layout default to config file
+- Add docs for setting Front Matter layout defaults
+- Use GitHub hosted theme
 
 ## v1.0.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ nav_order: 99
 
 # Changelog
 
+## v1.0.2
+
+- Update Jekyll version to 4.3.2
+- Update Webrick to 1.8
+- Add layout default to config file
+
 ## v1.0.1
 
 - Fix Sass compiling bug

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -387,3 +387,16 @@ layout: default
 ```
 
 {% endraw %}
+
+### Defining a default layout
+
+To properly load a layout template with all of its includes and styles, you must define which layout you wish to use. Just the HM Docs does this by defining the layout in page front matter, as shown above. If you wish to set a default layout and not explicitly state the layout in each template, you must add the following Front Matter defaults to your `_config.yml` file:
+
+```
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+    values:
+      layout: "default"
+```

--- a/just-the-hm-docs.gemspec
+++ b/just-the-hm-docs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "just-the-hm-docs"
-  spec.version       = "1.0.1.rc1"
+  spec.version       = "1.0.2.rc1"
   spec.authors       = ["Human Made"]
   spec.email         = ["info@humanmade.com"]
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   << 'just-the-hm-docs'
 
   spec.add_development_dependency "bundler", "~> 2.3.5"
-  spec.add_runtime_dependency "jekyll", ">= 3.8.5"
+  spec.add_runtime_dependency "jekyll", ">= 4.3.2"
   spec.add_runtime_dependency "jekyll-seo-tag", ">= 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1"
 end


### PR DESCRIPTION
We want all of our open source projects to be able to use this theme with as minimal setup and repetition as possible. But it appears we need Jekyll 4 to inherit site variables from the theme config. Inheriting the variables also seems to only work from GitHub hosted Gems, and not from RubyGems, so we'll switch to using the Gem from this repo. (If someone knows why or some other way to solve this, please let me know.)

This PR also:

- Adds docs for adding Front Matter layout defaults to the config file so that all markdown files don't need to specify a layout. This fixes a problem we found with Webpack Helpers not loading the theme properly if we removed the `github-pages` gem. Note: this does not appear to inherit and will need to be set in the site's config file.
- Removes the HM homepage link from the header, so that it's not forced to inherit to all of the other sites. (If those sites also want links in the header, it gets a bit crowded.)